### PR TITLE
Since we do not pass the mcaf-github-token down we can use the environmental secret with is in capital

### DIFF
--- a/sync-root/.github/workflows/update-changelog.yaml
+++ b/sync-root/.github/workflows/update-changelog.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.mcaf-github-token }}
+          token: ${{ secrets.MCAF_GITHUB_TOKEN }}
 
       - name: Update Changelog
         uses: stefanzweifel/changelog-updater-action@v1


### PR DESCRIPTION
How we did this in the past: https://github.com/schubergphilis/terraform-aws-mcaf-user/blob/8428c8d8864cccb9abec73977caff4ea5c87275b/.github/workflows/update-changelog.yml 
solves: https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/actions/runs/4597790393 