### PR TITLE
fix empty credentials in environment. Update checkov

### DIFF
--- a/sync-root/.github/workflows/terraform-validation.yaml
+++ b/sync-root/.github/workflows/terraform-validation.yaml
@@ -139,7 +139,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Checkov
-        uses: bridgecrewio/checkov-action@v12.2467.0
+        uses: bridgecrewio/checkov-action@v12.2577.0
         with:
           container_user: 1000
           directory: "/"

--- a/sync-root/.pre-commit-config.yaml
+++ b/sync-root/.pre-commit-config.yaml
@@ -14,6 +14,8 @@ repos:
         args:
           - --autofix
       - id: detect-aws-credentials
+        args:
+          - --allow-missing-credentials
       - id: detect-private-key
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.83.5
@@ -23,7 +25,7 @@ repos:
       - id: terraform_docs
       - id: terraform_validate
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 2.3.34
+    rev: 3.0.37
     hooks:
       - id: checkov
         verbose: false


### PR DESCRIPTION
Make the precommit check for credentials work when there are no credntals present in env

Update checkov to latest version

match the github action to the checkov  version