### PR TITLE
Remove gitlab runner module

### DIFF
--- a/.github/workflows/workflow-synchronization.yaml
+++ b/.github/workflows/workflow-synchronization.yaml
@@ -30,7 +30,6 @@ env:
     schubergphilis/terraform-github-mcaf-repository
     schubergphilis/terraform-gitlab-mcaf-group
     schubergphilis/terraform-gitlab-mcaf-project
-    schubergphilis/terraform-gitlab-mcaf-runner
     schubergphilis/terraform-tfe-mcaf-workspace
 
   WORKFLOW_FILES: |


### PR DESCRIPTION
After discussion that this is not the best candidate for the module, we decided to remove it.