### PR TITLE
Make "Terraform Validate" step optional

### DIFF
--- a/sync-root/.github/workflows/terraform-validation.yaml
+++ b/sync-root/.github/workflows/terraform-validation.yaml
@@ -9,6 +9,7 @@ permissions:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  TF_IN_AUTOMATION: 1
 
 jobs:
   fmt-lint-validate:
@@ -29,25 +30,28 @@ jobs:
         id: fmt
         run: terraform fmt -check -recursive
 
-      - name: Terraform Init
-        id: init
+      - name: Terraform Lint
+        id: lint
         run: |
+          echo "Checking ."
+          tflint --format compact
+
           for d in examples/*/; do
-            terraform -chdir=$d init
+            echo "Checking ${d} ..."
+            tflint --chdir=$d --format compact
           done
 
       - name: Terraform Validate
         id: validate
+        if: ${{ !vars.SKIP_TERRAFORM_VALIDATE }}
         run: |
           for d in examples/*/; do
+            echo "Checking ${d} ..."
+            terraform -chdir=$d init
             terraform -chdir=$d validate -no-color
           done
         env:
           AWS_DEFAULT_REGION: eu-west-1
-
-      - name: Terraform Lint
-        id: lint
-        run: tflint --no-color --recursive --format compact
 
       - uses: actions/github-script@v6
         if: github.event_name == 'pull_request' || always()


### PR DESCRIPTION
The current "Terraform Validate" step doesn't play nicely with workspaces containing Terraform tests so this adds a way to optionally skip it.

Also:
* Now looping using `tflint` and printing the directory name to see where issues are. This has been a pain-point for a while.
* Set `TF_IN_AUTOMATION` to reduce the amount of output generated.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
