### PR TITLE
Replace `misc` with `chore`

### DIFF
--- a/sync-root/.github/labels.yaml
+++ b/sync-root/.github/labels.yaml
@@ -16,10 +16,10 @@
   description: New feature or request
 - name: fix
   color: "d93f0b"
-  description: Something isn't working
-- name: misc
+  description: Fixes a bug
+- name: chore
   color: "6b93d3"
-  description: Miscellaneous task not covered by something else
+  description: Task not covered by something else (e.g. refactor, CI changes, tests)
 - name: no-changelog
   color: "cccccc"
   description: No entry should be added to the release notes and changelog

--- a/sync-root/.github/release-drafter-config.yaml
+++ b/sync-root/.github/release-drafter-config.yaml
@@ -1,82 +1,89 @@
-name-template: 'v$RESOLVED_VERSION'
-tag-template: 'v$RESOLVED_VERSION'
-version-template: '$MAJOR.$MINOR.$PATCH'
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+version-template: "$MAJOR.$MINOR.$PATCH"
 change-title-escapes: '\<*_&'
 
 categories:
-  - title: '🚀 Features'
+  - title: "🚀 Features"
     labels:
-      - 'breaking'
-      - 'enhancement'
-      - 'feature'
-  - title: '🐛 Bug Fixes'
+      - "breaking"
+      - "enhancement"
+      - "feature"
+  - title: "🐛 Bug Fixes"
     labels:
-      - 'bug'
-      - 'fix'
-      - 'security'
-  - title: '📖 Documentation'
+      - "bug"
+      - "fix"
+      - "security"
+  - title: "📖 Documentation"
     labels:
-      - 'documentation'
-  - title: '🧺 Miscellaneous'
+      - "documentation"
+  - title: "🧺 Miscellaneous"
     labels:
-      - 'misc'
+      - "chore"
 
 version-resolver:
   major:
     labels:
-      - 'breaking'
+      - "breaking"
   minor:
     labels:
-      - 'enhancement'
-      - 'feature'
+      - "enhancement"
+      - "feature"
   patch:
     labels:
-      - 'bug'
-      - 'documentation'
-      - 'fix'
-      - 'security'
-  default: 'minor'
+      - "bug"
+      - "chore"
+      - "documentation"
+      - "fix"
+      - "security"
+  default: "minor"
 
 autolabeler:
-  - label: 'documentation'
+  - label: "documentation"
     body:
-      - '/documentation/'
+      - "/documentation/"
     branch:
       - '/docs\/.+/'
     title:
-      - '/documentation/i'
-      - '/docs/i'
-  - label: 'bug'
+      - "/documentation/i"
+      - "/docs/i"
+  - label: "bug"
     body:
-      - '/bug/'
+      - "/bug/"
     branch:
       - '/bug\/.+/'
       - '/fix\/.+/'
     title:
-      - '/bug/i'
-      - '/fix/i'
-  - label: 'feature'
+      - "/bug/i"
+      - "/fix/i"
+  - label: "feature"
     branch:
       - '/feature\/.+/'
       - '/enhancement\/.+/'
     title:
-      - '/feature/i'
-      - '/feat/i'
-      - '/enhancement/i'
-  - label: 'breaking'
+      - "/feature/i"
+      - "/feat/i"
+      - "/enhancement/i"
+  - label: "breaking"
     body:
-      - '/breaking/'
+      - "/breaking change/i"
     branch:
       - '/breaking\/.+/'
     title:
-      - '/breaking/i'
-      - '/major/i'
+      - "/!:/"
+      - "/breaking/i"
+      - "/major/i"
+  - label: "chore"
+    branch:
+      - '/chore\/.+/'
+    title:
+      - "/chore/i"
 
 exclude-contributors:
-  - 'github-actions[bot]'
+  - "github-actions[bot]"
 
 exclude-labels:
-  - 'no-changelog'
+  - "no-changelog"
 
 template: |
   # What's Changed

--- a/sync-root/.github/workflows/pr-validation.yaml
+++ b/sync-root/.github/workflows/pr-validation.yaml
@@ -31,13 +31,13 @@ jobs:
           types: |
             breaking
             bug
+            chore
             docs
             documentation
             enhancement
             feat
             feature
             fix
-            misc
             security
           requireScope: false
           ignoreLabels: |
@@ -82,7 +82,7 @@ jobs:
       - uses: danielchabr/pr-labels-checker@v3.3
         id: lint_pr_labels
         with:
-          hasSome: breaking,bug,documentation,enhancement,feature,fix,misc,security
+          hasSome: breaking,bug,chore,documentation,enhancement,feature,fix,security
           githubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: marocchino/sticky-pull-request-comment@v2
@@ -94,7 +94,16 @@ jobs:
           message: |
             Hey there and thank you for opening this pull request! 👋🏼
 
-            The PR needs to have at least one of the following labels: breaking, bug, documentation, enhancement, feature, fix, misc, security.
+            The PR needs to have at least one of the following labels:
+
+            - breaking
+            - bug
+            - chore
+            - documentation
+            - enhancement
+            - feature
+            - fix
+            - security
 
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_labels.outputs.passed != false }}


### PR DESCRIPTION
Also updated `breaking` label to match the spec:

> a commit that has a footer `BREAKING CHANGE`:, or appends a `!` after the type/scope

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>