### PR TITLE
solve pre-commit deprecation warning

### DIFF
--- a/sync-root/.pre-commit-config.yaml
+++ b/sync-root/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # .pre-commit-config.yaml
-default_stages: [commit]
+default_stages: [pre-commit]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0


### PR DESCRIPTION
 top-level `default_stages` uses deprecated stage names (commit) which will be removed in a future version.