### PR TITLE
feat: Generate terraform docs recursively

### DIFF
--- a/sync-root/.github/workflows/terraform-validation.yaml
+++ b/sync-root/.github/workflows/terraform-validation.yaml
@@ -116,7 +116,7 @@ jobs:
       - name: Render terraform docs inside the README.md and push changes back to PR branch
         uses: terraform-docs/gh-actions@v1.3.0
         with:
-          args: --sort-by required
+          args: --sort-by required --recursive
           git-commit-message: "docs(readme): update module usage"
           git-push: true
           output-file: README.md


### PR DESCRIPTION
Add the `--recursive` flag to terraform-docs so that submodules can also be documented using terraform docs.

Example of this working:
* https://github.com/schubergphilis/terraform-azure-ep-identity-governance/pull/1/commits/ecdd9aac0239a40e8d8819f2c7811b084b367f45