### PR TITLE
fix issue with label-checker

### DIFF
--- a/sync-root/.github/workflows/pr-validation.yaml
+++ b/sync-root/.github/workflows/pr-validation.yaml
@@ -86,7 +86,7 @@ jobs:
         id: lint_pr_labels
         with:
           hasSome: breaking,bug,chore,documentation,enhancement,feature,fix,security
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          githubToken: ${{ secrets.MCAF_GITHUB_TOKEN }}
 
       - uses: marocchino/sticky-pull-request-comment@v2
         # When the previous steps fails, the workflow would stop. By adding this


### PR DESCRIPTION
Error: Check run status and conclusions can only be updated internally by GitHub Actions. Please see https://github.blog/changelog/2025-02-12-notice-of-upcoming-deprecations-and-breaking-changes-for-github-actions/#changes-to-check-run-status-modification

Workaround by using the MCAF token this can be updated again. A proper solution is in the making here: https://github.com/danielchabr/pr-labels-checker/pull/18 when that's implemented we can revert back to the GITHUB_TOKEN.