### PR TITLE
fix: escape GitHub expressions and use env vars in github-script

### DIFF
--- a/sync-root/.github/workflows/terraform-validation.yaml
+++ b/sync-root/.github/workflows/terraform-validation.yaml
@@ -63,50 +63,64 @@ jobs:
           terraform init
           terraform test
 
-      - uses: actions/github-script@v7
+      - name: Comment CI results
+        uses: actions/github-script@v7
         if: github.event_name == 'pull_request' || always()
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const fmt = process.env.FMT_RESULT;
+            const init = process.env.INIT_RESULT;
+            const lint = process.env.LINT_RESULT;
+            const validate = process.env.VALIDATE_RESULT;
+            const validateOutput = process.env.VALIDATE_STDOUT;
+
             // 1. Retrieve existing bot comments for the PR
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
             })
+
             const botComment = comments.find(comment => {
               return comment.user.type === 'Bot' && comment.body.includes('Terraform Format and Style')
             })
 
             // 2. Prepare format of the comment
-            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
-            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
-            #### Terraform Lint 📖\`${{ steps.lint.outcome }}\`
-            #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+            const output = `#### Terraform Format and Style 🖌 \`${fmt}\`
+            #### Terraform Initialization ⚙️ \`${init}\`
+            #### Terraform Lint 📖 \`${lint}\`
+            #### Terraform Validation 🤖 \`${validate}\`
             <details><summary>Validation Output</summary>
 
             \`\`\`\n
-            ${{ steps.validate.outputs.stdout }}
+            ${validateOutput}
             \`\`\`
 
             </details>`;
 
             // 3. If we have a comment, update it, otherwise create a new one
             if (botComment) {
-              github.rest.issues.updateComment({
+              await github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: botComment.id,
                 body: output
               })
             } else {
-              github.rest.issues.createComment({
+              await github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 body: output
               })
             }
+        env:
+          FMT_RESULT: ${{ steps.fmt.outcome }}
+          INIT_RESULT: ${{ steps.init.outcome }}
+          LINT_RESULT: ${{ steps.lint.outcome }}
+          VALIDATE_RESULT: ${{ steps.validate.outcome }}
+          VALIDATE_STDOUT: ${{ steps.validate.outputs.stdout }}
 
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the `github-script` step in the Terraform validation workflow to avoid using `${{ }}` expressions inside JavaScript. Values from previous steps are now passed via `env` and accessed using `process.env.*` to prevent syntax errors.

Fixes this error we see in another repository:

![image](https://github.com/user-attachments/assets/eb8df180-b095-4454-b8a2-278b02865e52)


Enhancements to CI result commenting:

* [`sync-root/.github/workflows/terraform-validation.yaml`](diffhunk://#diff-05ca9f11c7272741c9f3deadd32fee748efb3634dab8c3116e3b902eed229b61L66-R123): Added environment variables (`FMT_RESULT`, `INIT_RESULT`, `LINT_RESULT`, `VALIDATE_RESULT`, `VALIDATE_STDOUT`) to store step outcomes and outputs for better readability and maintainability. Updated the script to use these variables when preparing the comment format.
* [`sync-root/.github/workflows/terraform-validation.yaml`](diffhunk://#diff-05ca9f11c7272741c9f3deadd32fee748efb3634dab8c3116e3b902eed229b61L66-R123): Modified the bot comment handling logic to ensure asynchronous operations (`updateComment` and `createComment`) are awaited, improving reliability.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
