### PR TITLE
add new module terraform-aws-mcaf-route53-profile-sharing

### DIFF
--- a/.github/workflows/workflow-synchronization.yaml
+++ b/.github/workflows/workflow-synchronization.yaml
@@ -35,6 +35,7 @@ env:
     schubergphilis/terraform-aws-mcaf-redshift
     schubergphilis/terraform-aws-mcaf-resource-scheduler
     schubergphilis/terraform-aws-mcaf-role
+    schubergphilis/terraform-aws-mcaf-route53-profile-sharing
     schubergphilis/terraform-aws-mcaf-route53-resolver
     schubergphilis/terraform-aws-mcaf-s3
     schubergphilis/terraform-aws-mcaf-saas-audit-logs


### PR DESCRIPTION
Adds new module [terraform-aws-mcaf-route53-profile-sharing](https://github.com/schubergphilis/terraform-aws-mcaf-route53-profile-sharing) to the worklflow synchronization.