### PR TITLE
Add mcaf-route53-zones repo

### DIFF
--- a/.github/workflows/workflow-synchronization.yaml
+++ b/.github/workflows/workflow-synchronization.yaml
@@ -38,6 +38,7 @@ env:
     schubergphilis/terraform-aws-mcaf-role
     schubergphilis/terraform-aws-mcaf-route53-profiles
     schubergphilis/terraform-aws-mcaf-route53-resolver
+    schubergphilis/terraform-aws-mcaf-route53-zones
     schubergphilis/terraform-aws-mcaf-s3
     schubergphilis/terraform-aws-mcaf-saas-audit-logs
     schubergphilis/terraform-aws-mcaf-security-group


### PR DESCRIPTION
This PR adds the route53-zone repository.

This repo was not adopted yet