### PR TITLE
feat: update release drafter to v7

### DIFF
--- a/sync-root/.github/workflows/pr-validation.yaml
+++ b/sync-root/.github/workflows/pr-validation.yaml
@@ -19,11 +19,9 @@ jobs:
   autolabeler:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter/autolabeler@v7
         with:
           config-name: release-drafter-config.yaml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   title-checker:
     runs-on: ubuntu-latest

--- a/sync-root/.github/workflows/release-drafter.yaml
+++ b/sync-root/.github/workflows/release-drafter.yaml
@@ -24,10 +24,8 @@ jobs:
   draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v7
         with:
           publish: false
           prerelease: false
           config-name: release-drafter-config.yaml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Migrate release-drafter/release-drafter from v6 to v7.

Changes:

- Bump release-drafter/release-drafter to @v7 
- Remove env: GITHUB_TOKEN blocks (v7 defaults token to ${{ github.token }})