### PR TITLE
feat(terraform-validation): initialize tflint plugins before linting

### DIFF
--- a/sync-root/.github/workflows/terraform-validation.yaml
+++ b/sync-root/.github/workflows/terraform-validation.yaml
@@ -36,10 +36,14 @@ jobs:
       - name: Terraform Lint
         id: lint
         run: |
+          echo "Installing tflint plugins, if any"
+          tflint --init
           echo "Checking ."
           tflint --format compact
 
           for d in examples/*/; do
+            echo "Installing tflint plugins, if any"
+            tflint --chdir=$d  --init
             echo "Checking ${d} ..."
             tflint --chdir=$d --format compact
           done


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Run `tflint --init` before linting in `sync-root/.github/workflows/terraform-validation.yaml` — once for the root module and again inside each `examples/*` directory.

## :rocket: Motivation

Without `--init`, any module that declares a plugin in `.tflint.hcl` (e.g. `terraform-linters/tflint-ruleset-aws`) fails the lint step with:

```
Failed to initialize plugins; Plugin "aws" not found. Did you run "tflint --init"?
```

`setup-tflint@v4` installs the `tflint` binary but does not download plugins; that has to happen per working directory. The current workflow skips this, so plugin-using modules cannot lint cleanly at all. Adding the init in both the root step and the `examples/*` loop unblocks them.

## :pencil: Additional Information

Verified locally with four sandbox modules (root only / root + examples × no plugin / aws plugin), running the lint step both as proposed and as it exists today:

| Case | New step | Old step |
|---|---|---|
| Bare module, no plugin | pass | pass |
| Module + examples, no plugin | pass | pass |
| Module with plugin | pass | fail (`Plugin "aws" not found`) |
| Module + examples both with plugin | pass | fail at root |

`--init` is a no-op for modules that declare no plugins, so existing repos without a `.tflint.hcl` see no behavior change. Per-example `--init` is needed because each example directory has its own tflint working dir and may declare a different plugin set than the root module.

Refs: <https://github.com/terraform-linters/setup-tflint#usage>, <https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md>
